### PR TITLE
Change to be ASCII-compliant

### DIFF
--- a/dialog/en-us/question.dialog
+++ b/dialog/en-us/question.dialog
@@ -1,4 +1,4 @@
-I'm sorry I can’t help you with that.
+I'm sorry I can't help you with that.
 I'm not sure how to help you with that.
 I don't understand, but I'm learning new things everyday.
 I'm not sure how to answer that.


### PR DESCRIPTION
This was one of two `dialog` files that was causing the `extract.py` script for Pootle to bork due to `xgettext` exiting on non-ASCII text in the file. ASCII-fied the text.